### PR TITLE
Podpora pro PHP 8

### DIFF
--- a/.github/workflows/php-package-ci.yml
+++ b/.github/workflows/php-package-ci.yml
@@ -1,0 +1,32 @@
+name: Package CI
+
+on:
+  pull_request:
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ 7.4, 8.0 ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+      - uses: getong/rabbitmq-action@v1.2
+        with:
+          rabbitmq version: '3.8.2-management-alpine'
+          host port: 5672
+          rabbitmq user: 'guest'
+          rabbitmq password: 'guest'
+          rabbitmq vhost: '/'
+
+      - run: composer update --no-interaction --no-suggest --no-progress --prefer-dist
+
+      - run: vendor/bin/parallel-lint -e php,phpt --exclude vendor .
+
+      - run: vendor/bin/tester -s -c ./tests/php.ini-unix ./tests/KdybyTests/
+
+      - run: vendor/bin/phpstan analyse -l 2 -c phpstan.neon src tests/KdybyTests

--- a/composer.json
+++ b/composer.json
@@ -16,24 +16,21 @@
 		}
 	],
 	"require": {
-		"php": "^7.1",
-		"nette/di": "~2.4.10 || ^3.0",
+		"php": "^7.4 | ^8.0",
+		"nette/di": "^3.0",
 		"nette/utils": "^3.0",
-
-		"php-amqplib/php-amqplib": "~2.6.2"
+		"php-amqplib/php-amqplib": "~3.0.0"
 	},
 	"require-dev": {
 		"kdyby/console": "~2.8",
-
-		"nette/bootstrap": "~2.4 || ~3.0",
+		"nette/bootstrap": "~3.0",
 		"latte/latte": "~2.4",
 		"tracy/tracy": "~2.4",
-		"phpstan/phpstan-shim": "^0.11.4",
-		"kdyby/coding-standard": "dev-master",
+		"phpstan/phpstan": "^0.12.88",
 		"php-coveralls/php-coveralls": "^2.1",
 		"nette/tester": "^2.3.2",
 		"mockery/mockery": "~1.3.0",
-		"jakub-onderka/php-parallel-lint": "^1.0",
+		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"typo3/class-alias-loader": "^1.0",
 		"nette/caching": "^3.0"
 	},
@@ -52,6 +49,7 @@
 		}
 	},
 	"minimum-stability": "dev",
+  	"prefer-stable": true,
 	"extra": {
 		"branch-alias": {
 			"dev-master": "1.3-dev"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 parameters:
 	ignoreErrors:
-		- '#Parameter \$callback of method KdybyTests\\RabbitMq\\Mock\\ChannelMock\:\:basic_consume\(\) has invalid typehint type PhpAmqpLib\\Channel\\callback.#'
 
 	excludes_analyse:
 		- *src/Kdyby/RabbitMq/DI/ClassAliasMap.php

--- a/tests/KdybyTests/RabbitMq/BaseAmqpTest.phpt
+++ b/tests/KdybyTests/RabbitMq/BaseAmqpTest.phpt
@@ -27,7 +27,7 @@ class BaseAmqpTest extends \KdybyTests\RabbitMq\TestCase
 
 		Assert::exception(static function () use ($consumer): void {
 			$consumer->getChannel();
-		}, \ErrorException::class, 'stream_socket_client(): unable to connect to tcp://localhost:123 (Connection refused)');
+		}, \PhpAmqpLib\Exception\AMQPIOException::class, 'stream_socket_client(): Unable to connect to tcp://localhost:123 (Connection refused)');
 	}
 
 }

--- a/tests/KdybyTests/RabbitMq/Mock/ChannelMock.php
+++ b/tests/KdybyTests/RabbitMq/Mock/ChannelMock.php
@@ -312,7 +312,7 @@ class ChannelMock extends \Kdyby\RabbitMq\Channel
 	)
 	{
 		$this->calls[] = [__FUNCTION__] + \get_defined_vars();
-		parent::basic_return($args, $msg);
+		return parent::basic_return($args, $msg);
 	}
 
 	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint,SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint,PSR1.Methods.CamelCapsMethodName

--- a/tests/php.ini-unix
+++ b/tests/php.ini-unix
@@ -1,0 +1,3 @@
+extension=sockets
+extension=iconv
+extension=tokenizer


### PR DESCRIPTION
⚠️ cíl merge je branch upgrade-nette, kterou by bylo skvělé mergnout do masteru: https://github.com/Kdyby/RabbitMq/pull/72

- drop podpory PHP starších než 7.4
- drop podpory nette/di 2.4
- aktualizace závislostí